### PR TITLE
docs: add final Astilba Env bridge

### DIFF
--- a/.changeset/final-bridge-to-astilba-env.md
+++ b/.changeset/final-bridge-to-astilba-env.md
@@ -1,0 +1,5 @@
+---
+"next-dynamic-env": patch
+---
+
+This final bridge marks the package as retired in favour of exact public `@astilba/env@0.2.2`; adds migration guidance; and changes no runtime behavior.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -13,7 +13,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      packages: write
       id-token: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -21,39 +20,39 @@ jobs:
       TURBO_API: ${{ secrets.TURBO_API }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20.x
-          cache: 'pnpm'
+          node-version: 24.18.1
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Update npm for Trusted Publishing
-        run: npm install -g npm@latest
-
-      - name: Check npm version
-        run: npm --version
+      - name: Verify Trusted Publishing runtime
+        run: |
+          test "$(node --version)" = "v24.18.1"
+          test "$(npm --version)" = "11.16.0"
 
       - name: Build package
         run: pnpm build:packages
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           publish: pnpm changeset publish
           title: "chore: release package"
           commit: "chore: release package"
+          commitMode: github-api
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,13 +61,15 @@ jobs:
       - name: Publish Summary
         if: steps.changesets.outputs.published == 'true'
         run: |
-          echo "## 🎉 Published Packages" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The following packages were published to npm:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.changesets.outputs.publishedPackages }}' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### GitHub Releases" >> $GITHUB_STEP_SUMMARY
-          echo "GitHub releases have been created automatically for the published versions." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## 🎉 Published Packages"
+            echo ""
+            echo "The following packages were published to npm:"
+            echo ""
+            echo '```json'
+            echo '${{ steps.changesets.outputs.publishedPackages }}'
+            echo '```'
+            echo ""
+            echo "### GitHub Releases"
+            echo "GitHub releases have been created automatically for the published versions."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -56,7 +56,6 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Summary
         if: steps.changesets.outputs.published == 'true'

--- a/packages/next-dynamic-env/README.md
+++ b/packages/next-dynamic-env/README.md
@@ -4,6 +4,11 @@
 [![npm downloads](https://img.shields.io/npm/dm/next-dynamic-env.svg)](https://www.npmjs.com/package/next-dynamic-env)
 [![license](https://img.shields.io/npm/l/next-dynamic-env.svg)](https://github.com/reesmorris/next-dynamic-env/blob/main/LICENSE)
 
+> [!IMPORTANT]
+> This package is no longer actively maintained. New and existing projects should migrate to exact public [`@astilba/env@0.2.2`](https://astilba.com/docs/env/overview/) with the [stable migration guide](https://astilba.com/docs/env/migrate-from-next-dynamic-env/).
+>
+> This is an architectural migration; not a package rename or compatibility shim. Existing `next-dynamic-env` versions, tarballs, and history will remain available. This final bridge changes no runtime API or behavior.
+
 Type-safe runtime environment variables for Next.js – no more rebuilding for config changes!
 
 ## Why?

--- a/packages/next-dynamic-env/package.json
+++ b/packages/next-dynamic-env/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-dynamic-env",
   "version": "1.3.0",
-  "description": "Runtime environment variables for dockerized Next.js apps",
+  "description": "Retired; migrate to @astilba/env@0.2.2",
   "author": "Rees Morris",
   "license": "MIT",
   "keywords": [
@@ -14,7 +14,7 @@
     "variables"
   ],
   "repository": "https://github.com/ReesMorris/next-dynamic-env",
-  "homepage": "https://github.com/ReesMorris/next-dynamic-env#readme",
+  "homepage": "https://astilba.com/docs/env/migrate-from-next-dynamic-env/",
   "bugs": "https://github.com/ReesMorris/next-dynamic-env/issues",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

- add the final retirement notice and exact `@astilba/env@0.2.2` migration links
- prepare patch release `next-dynamic-env@1.3.1` without changing runtime behavior
- update package description and homepage for the maintained migration path
- repair the failed Changesets release runtime with exact Node 24.18.1 and npm 11.16.0
- pin every high-trust release action; disable release-job caching; use GitHub API commits; and remove the unnecessary GitHub Packages permission

## Compatibility boundary

`packages/next-dynamic-env/src`, the export map, and runtime API are unchanged. The candidate pack contains the expected README, package metadata, and six built runtime/type/map files. Every one of those six files is SHA-256 byte-identical to public `next-dynamic-env@1.3.0`.

## Validation

- frozen pnpm install
- Actionlint and Syncpack
- package lint and TypeScript check
- package build
- 18 test files and 234/234 tests in the neutral colour-test environment
- Changesets status; exact patch bump from 1.3.0 to 1.3.1
- dry-run package pack and metadata/README inspection
- independent final review; no actionable findings
- complete whitespace and protected-runtime diff checks

## Release boundary

This is intentionally a draft until npm authentication is proven for the final release workflow. Merging the release PR, publishing 1.3.1, deprecating existing versions, and archiving the repository remain ordered later gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a maintenance notice directing users to migrate from `next-dynamic-env` to `@astilba/env@0.2.2`.
  * Added links to migration documentation and clarified that runtime APIs and behavior remain unchanged.

* **Chores**
  * Marked `next-dynamic-env` as retired and updated its homepage to the migration guide.
  * Improved release workflow reliability with pinned tooling and explicit version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->