### PR TITLE
docs: make Env retirement guidance version-independent

### DIFF
--- a/.changeset/quiet-env-retirement.md
+++ b/.changeset/quiet-env-retirement.md
@@ -1,0 +1,4 @@
+---
+---
+
+Keep the retired package's migration guidance version-independent.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/npm/l/next-dynamic-env.svg)](https://github.com/reesmorris/next-dynamic-env/blob/main/LICENSE)
 
 > [!IMPORTANT]
-> This package is no longer actively maintained. New and existing projects should migrate to exact public [`@astilba/env@0.2.2`](https://astilba.com/docs/env/overview/) with the [stable migration guide](https://astilba.com/docs/env/migrate-from-next-dynamic-env/).
+> This package is no longer actively maintained. New and existing projects should migrate to [`@astilba/env`](https://astilba.com/docs/env/overview/) with the [stable migration guide](https://astilba.com/docs/env/migrate-from-next-dynamic-env/).
 >
 > This is an architectural migration; not a package rename or compatibility shim. Existing `next-dynamic-env` versions, tarballs, and history will remain available. This final bridge changes no runtime API or behavior.
 

--- a/packages/next-dynamic-env/README.md
+++ b/packages/next-dynamic-env/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/npm/l/next-dynamic-env.svg)](https://github.com/reesmorris/next-dynamic-env/blob/main/LICENSE)
 
 > [!IMPORTANT]
-> This package is no longer actively maintained. New and existing projects should migrate to exact public [`@astilba/env@0.2.2`](https://astilba.com/docs/env/overview/) with the [stable migration guide](https://astilba.com/docs/env/migrate-from-next-dynamic-env/).
+> This package is no longer actively maintained. New and existing projects should migrate to [`@astilba/env`](https://astilba.com/docs/env/overview/) with the [stable migration guide](https://astilba.com/docs/env/migrate-from-next-dynamic-env/).
 >
 > This is an architectural migration; not a package rename or compatibility shim. Existing `next-dynamic-env` versions, tarballs, and history will remain available. This final bridge changes no runtime API or behavior.
 

--- a/packages/next-dynamic-env/package.json
+++ b/packages/next-dynamic-env/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-dynamic-env",
   "version": "1.3.1",
-  "description": "Retired; migrate to @astilba/env@0.2.2",
+  "description": "Retired; migrate to @astilba/env",
   "author": "Rees Morris",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary

- remove the stale Astilba Env release number from both retirement notices
- make the package description version-independent
- keep exact install guidance in the actively maintained Astilba documentation

This changes no runtime behavior and prevents the retired repository from requiring an edit for every Env release.

## Validation

- `pnpm check`
- `env -u NO_COLOR -u TERM pnpm test`
- `pnpm build`
- CodeRabbit CLI review; zero findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated migration guidance to recommend the unversioned `@astilba/env` package.
  - Clarified retirement of the `quiet-env` package and provided version-independent migration instructions.
  - Updated package descriptions and related notices to reflect the recommended migration.
  - Confirmed that the migration does not change runtime APIs or application behavior.

- **Chores**
  - Added release metadata documenting the package retirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->